### PR TITLE
#1120 Improvements for Reviewer stats updates

### DIFF
--- a/database/buildSchema/43_views_functions_triggers.sql
+++ b/database/buildSchema/43_views_functions_triggers.sql
@@ -1660,99 +1660,14 @@ $$
 LANGUAGE sql
 STABLE;
 
--- Function to update assigner/reviewer lists on applications and insert/update
--- reviewer/assigner actions on application_reviewer_action, by making calls to
--- the above `single_application_detail` function for the appropriate
--- user/application combo(s)
+-- These functions now performed by server in 'updateReviewerStats.ts':
 DROP FUNCTION IF EXISTS public.update_application_reviewer_stats CASCADE;
--- CREATE OR REPLACE FUNCTION public.update_application_reviewer_stats ()
---     RETURNS TRIGGER
---      -- This allows the function to be run as admin user, otherwise it'll only
---      -- be able to query rows the current user has access to.
---     SECURITY DEFINER
---     AS $$
+DROP FUNCTION IF EXISTS public.update_application_new_assigner_stats CASCADE;
+DROP FUNCTION IF EXISTS public.update_reviewer_stats_from_status CASCADE;
+DROP FUNCTION IF EXISTS public.update_application_reviewer_stats_for_application CASCADE;
 
--- DECLARE
---     user_ids integer[];
---     userid integer;
-
--- BEGIN
--- -- reviewer and assigner lists
---     IF TG_OP != 'INSERT' THEN
---         WITH lists AS (
---                 SELECT reviewers, assigners
---                 FROM single_application_detail(NEW.application_id)
---             ) 
---         UPDATE public.application
---             SET reviewer_list = (SELECT reviewers FROM lists),
---             assigner_list = (SELECT assigners FROM lists)
---             WHERE id = NEW.application_id;
---     END IF;
-
---     -- REVIEWER/ASSIGNER actions
---     -- When updating review_assignments, we re-calculate for every
---     -- reviewer/assigner associated with this application.
---     IF TG_OP = 'UPDATE' THEN
---         user_ids = ARRAY(
---             -- Creates an array of distinct user ids for all assigners/reviewers
---             -- who can interact with this application
---             SELECT DISTINCT UNNEST(ARRAY[reviewer_id, raaj.assigner_id])
---             FROM review_assignment ra
---             LEFT JOIN review_assignment_assigner_join raaj
---             ON ra.id = raaj.review_assignment_id
---             WHERE application_id = NEW.application_id);
---     ELSE
---     -- But when inserting, just update for the new reviewer
---         user_ids = ARRAY[NEW.reviewer_id];
---     END IF;
-
---     FOREACH userid IN ARRAY user_ids LOOP
-
---         -- Sometimes NULL is included in above array of IDs, which breaks the
---         -- function
---         CONTINUE WHEN userid IS NULL;
-        
---         -- Remove existing
---         UPDATE public.application_reviewer_action
---             SET reviewer_action = NULL,
---             assigner_action = NULL
---             WHERE application_id = NEW.application_id
---             AND user_id = userid;
-
---         -- Insert new
---         WITH actions AS (
---             SELECT reviewer_action, assigner_action
---                 FROM single_application_detail(NEW.application_id, userid)
---             ) 
---         INSERT INTO public.application_reviewer_action
---             (user_id, application_id, reviewer_action, assigner_action)  
---         VALUES(
---             userid,
---             NEW.application_id,
---             (SELECT reviewer_action FROM actions),
---             (SELECT assigner_action FROM actions)
---          )
---          ON CONFLICT (user_id, application_id)
---          DO UPDATE
---             SET reviewer_action = (SELECT reviewer_action FROM actions),
---             assigner_action = (SELECT assigner_action FROM actions);
---     END LOOP;
-
---     -- Clean up NULL records
---     DELETE FROM public.application_reviewer_action
---     WHERE application_id = NEW.application_id
---     AND reviewer_action IS NULL
---     AND assigner_action IS NULL;
-
--- RETURN NULL;
-
--- END;
--- $$
--- LANGUAGE plpgsql;
-
-
--- Trigger for the above on review_assignment
-
+-- Function to notify server on updates to tables that will require updating of
+-- available reviewer actions. This replaces the above 4 functions.
 CREATE OR REPLACE FUNCTION public.notify_server_to_update_reviewer_stats ()
     RETURNS TRIGGER
     AS $trigger_event$
@@ -1764,6 +1679,8 @@ END;
 $trigger_event$
 LANGUAGE plpgsql;
 
+-- Triggers to trigger the above function
+    -- for review_assignment
 DROP TRIGGER IF EXISTS update_application_reviewer_stats ON public.review_assignment;
 CREATE TRIGGER update_application_reviewer_stats
     AFTER INSERT OR UPDATE OF status, allowed_sections, assigned_sections
@@ -1771,182 +1688,26 @@ CREATE TRIGGER update_application_reviewer_stats
     FOR EACH ROW
     EXECUTE FUNCTION public.notify_server_to_update_reviewer_stats ();
 
-    
--- Function to update assigner/reviewer lists on applications and insert/update
--- assigner actions on application_reviewer_action when records are inserted
--- into review_assignment_assigner_join
--- This function ONLY runs on INSERT -- UPDATEs are handled by the above
--- update_application_reviewer_stats function
-DROP FUNCTION IF EXISTS public.update_application_new_assigner_stats CASCADE;
--- CREATE OR REPLACE FUNCTION public.update_application_new_assigner_stats ()
---     RETURNS TRIGGER
---      -- This allows the function to be run as admin user, otherwise it'll only
---      -- be able to query rows the current user has access to.
---     SECURITY DEFINER
---     AS $$
-
--- DECLARE
---     userId integer;
---     applicationId integer;
-
--- BEGIN
--- -- Get application_id from review_assignment
-
---     applicationId = (SELECT application_id FROM review_assignment
---         WHERE id = NEW.review_assignment_id);
---     userId = NEW.assigner_id;
-
--- -- reviewer and assigner lists
---     WITH lists AS (
---         SELECT assigners
---         FROM single_application_detail(applicationId)
---     ) 
---     UPDATE public.application
---         SET assigner_list = (SELECT assigners FROM lists)
---         WHERE id = applicationId;
-
---     -- ASSIGNER action
-    
---     -- Remove existing
---     UPDATE public.application_reviewer_action
---         SET assigner_action = NULL
---         WHERE application_id = applicationId
---         AND user_id = userId;
-
---     -- Insert new
---     WITH actions AS (
---         SELECT assigner_action
---             FROM single_application_detail(applicationId, userId)
---         ) 
---     INSERT INTO public.application_reviewer_action
---         (user_id, application_id, assigner_action)  
---     VALUES(
---         userid,
---         applicationId,
---         (SELECT assigner_action FROM actions)
---         )
---         ON CONFLICT (user_id, application_id)
---         DO UPDATE
---         SET assigner_action = (SELECT assigner_action FROM actions);
-
---     -- Clean up NULL records
---     DELETE FROM public.application_reviewer_action
---     WHERE application_id = applicationId
---     AND reviewer_action IS NULL
---     AND assigner_action IS NULL;
-
--- RETURN NULL;
-
--- END;
--- $$
--- LANGUAGE plpgsql;
-
-
- 
-DROP TRIGGER IF EXISTS update_application_new_assigner_stats ON public.review_assignment;
+    -- for review_assignment_assigner_join
+DROP TRIGGER IF EXISTS update_application_new_assigner_stats ON public.review_assignment_assigner_join;
 CREATE TRIGGER update_application_new_assigner_stats
     AFTER INSERT ON public.review_assignment_assigner_join
     FOR EACH ROW
     EXECUTE FUNCTION public.notify_server_to_update_reviewer_stats ();
 
--- Trigger for the above on review_assignment_assigner_join
-
-
--- Function to update insert/update reviewer/assigner actions on
--- application_reviewer_action when review_status is updated, by making calls to
--- the above `single_application_detail` function for the appropriate
--- user/application combo(s)
-DROP FUNCTION IF EXISTS public.update_reviewer_stats_from_status CASCADE;
-CREATE OR REPLACE FUNCTION public.update_reviewer_stats_from_status ()
-    RETURNS TRIGGER
-     -- This allows the function to be run as admin user, otherwise it'll only
-     -- be able to query rows the current user has access to.
-    SECURITY DEFINER
-    AS $$
-
-DECLARE
-    app_id integer;
-    rev_id integer;
-    ass_id integer;
-
-BEGIN
-    -- Get application id
-    app_id = (
-        SELECT r.application_id FROM review r
-        WHERE id = NEW.review_id
-    );
-
-    -- Get reviewer_id and assigner_id
-    SELECT ra.reviewer_id, ra.assigner_id
-        INTO rev_id, ass_id
-        FROM review_assignment ra
-        WHERE id = (
-            SELECT review_assignment_id FROM review
-            WHERE id = NEW.review_id
-        );
-        
-    -- Update reviewer
-    UPDATE public.application_reviewer_action
-            SET reviewer_action = NULL
-            WHERE application_id = app_id
-            AND user_id = rev_id;
-
-    WITH reviewer_action AS (
-            SELECT reviewer_action
-                FROM single_application_detail(app_id, rev_id)
-            ) 
-        INSERT INTO public.application_reviewer_action
-            (user_id, application_id, reviewer_action)  
-        VALUES(
-            rev_id,
-            app_id,
-            (SELECT reviewer_action FROM reviewer_action)
-         )
-         ON CONFLICT (user_id, application_id)
-         DO UPDATE
-            SET reviewer_action = (SELECT reviewer_action FROM reviewer_action);
-
-    -- Update assigner
-    UPDATE public.application_reviewer_action
-            SET assigner_action = NULL
-            WHERE application_id = app_id
-            AND user_id = ass_id;
-
-    WITH assigner_action AS (
-            SELECT assigner_action
-                FROM single_application_detail(app_id, ass_id)
-            ) 
-        INSERT INTO public.application_reviewer_action
-            (user_id, application_id, assigner_action)  
-        VALUES(
-            ass_id,
-            app_id,
-            (SELECT assigner_action FROM assigner_action)
-         )
-         ON CONFLICT (user_id, application_id)
-         DO UPDATE
-            SET assigner_action = (SELECT assigner_action FROM assigner_action);
-
-
-    -- Clean up NULL records
-    DELETE FROM public.application_reviewer_action
-    WHERE application_id = app_id
-    AND reviewer_action IS NULL
-    AND assigner_action IS NULL;
-
-RETURN NULL;
-
-END;
-$$
-LANGUAGE plpgsql;
-
-
--- Trigger for the above on review_status_history
+    -- for review_status_history
 DROP TRIGGER IF EXISTS update_reviewer_stats_from_status ON public.review_status_history;
 CREATE TRIGGER update_reviewer_stats_from_status
     AFTER INSERT ON public.review_status_history
     FOR EACH ROW
-    EXECUTE FUNCTION public.update_reviewer_stats_from_status ();
+    EXECUTE FUNCTION public.notify_server_to_update_reviewer_stats ();
+
+    -- for application
+DROP TRIGGER IF EXISTS update_application_reviewer_stats_for_application ON public.application;
+CREATE TRIGGER update_application_reviewer_stats_for_application
+    AFTER UPDATE OF outcome ON public.application
+    FOR EACH ROW
+    EXECUTE FUNCTION public.notify_server_to_update_reviewer_stats ();
 
 -- This is a dummy table for the application list. Needs to be defined so that
 -- GraphQL types for the list get exposed by Postgraphile
@@ -1972,71 +1733,6 @@ CREATE TABLE IF NOT EXISTS application_list_shape (
     assigner_action public.assigner_action
 );
 
--- Function to update ALL reviewer actions for a given application whenever the
--- application OUTCOME changes
-DROP FUNCTION IF EXISTS public.update_application_reviewer_stats_for_application CASCADE;
-CREATE OR REPLACE FUNCTION public.update_application_reviewer_stats_for_application ()
-	RETURNS TRIGGER
-	SECURITY DEFINER
-	AS $$
-	
-    DECLARE reviewer_ids integer[];
-    DECLARE rev_id integer;
-
-    BEGIN
-        reviewer_ids = ARRAY(
-        SELECT DISTINCT reviewer_id FROM review_assignment
-            where application_id = NEW.id UNION 
-            SELECT DISTINCT assigner_id from public.review_assignment_assigner_join
-            WHERE review_assignment_id IN (
-                SELECT id FROM public.review_assignment
-                where application_id = NEW.id
-            ) 
-        );
-
-        FOREACH rev_id IN ARRAY reviewer_ids LOOP
-        -- Remove existing
-            UPDATE public.application_reviewer_action
-                SET reviewer_action = NULL,
-                assigner_action = NULL
-                WHERE application_id = NEW.id
-                AND user_id = rev_id;
-        -- Insert new
-            WITH actions AS (
-                SELECT reviewer_action, assigner_action
-                    FROM single_application_detail(NEW.id, rev_id)
-                ) 
-            INSERT INTO public.application_reviewer_action
-                (user_id, application_id, reviewer_action, assigner_action)  
-            VALUES(
-                rev_id,
-                NEW.id,
-                (SELECT reviewer_action FROM actions),
-                (SELECT assigner_action FROM actions)
-            )
-            ON CONFLICT (user_id, application_id)
-            DO UPDATE
-                SET reviewer_action = (SELECT reviewer_action FROM actions),
-                assigner_action = (SELECT assigner_action FROM actions);
-        END LOOP;
-
-        -- Clean up NULL records
-        DELETE FROM public.application_reviewer_action
-        WHERE application_id = NEW.id
-        AND reviewer_action IS NULL
-        AND assigner_action IS NULL;
-
-        RETURN NULL;
-    END;
-    $$
-    LANGUAGE plpgsql;
-
--- Trigger to run above function when outcome changes on application
-DROP TRIGGER IF EXISTS update_application_reviewer_stats_for_application ON public.application;
-CREATE TRIGGER update_application_reviewer_stats_for_application
-    AFTER UPDATE OF outcome ON public.application
-    FOR EACH ROW
-    EXECUTE FUNCTION public.update_application_reviewer_stats_for_application ();
 
 -- Special VIEW to list users using no security restrictions, which we join to
 -- the application list to yield associated applicants

--- a/database/buildSchema/43_views_functions_triggers.sql
+++ b/database/buildSchema/43_views_functions_triggers.sql
@@ -1683,15 +1683,8 @@ LANGUAGE plpgsql;
     -- for review_assignment
 DROP TRIGGER IF EXISTS update_application_reviewer_stats ON public.review_assignment;
 CREATE TRIGGER update_application_reviewer_stats
-    AFTER INSERT OR UPDATE OF status, allowed_sections, assigned_sections
+    AFTER UPDATE OF status, allowed_sections, assigned_sections
      ON public.review_assignment
-    FOR EACH ROW
-    EXECUTE FUNCTION public.notify_server_to_update_reviewer_stats ();
-
-    -- for review_assignment_assigner_join
-DROP TRIGGER IF EXISTS update_application_new_assigner_stats ON public.review_assignment_assigner_join;
-CREATE TRIGGER update_application_new_assigner_stats
-    AFTER INSERT ON public.review_assignment_assigner_join
     FOR EACH ROW
     EXECUTE FUNCTION public.notify_server_to_update_reviewer_stats ();
 
@@ -1708,6 +1701,10 @@ CREATE TRIGGER update_application_reviewer_stats_for_application
     AFTER UPDATE OF outcome ON public.application
     FOR EACH ROW
     EXECUTE FUNCTION public.notify_server_to_update_reviewer_stats ();
+
+    -- for review_assignment_assigner_join (no longer required, updated by
+    -- generateReviewAssignments Action instead)
+DROP TRIGGER IF EXISTS update_application_new_assigner_stats ON public.review_assignment_assigner_join;
 
 -- This is a dummy table for the application list. Needs to be defined so that
 -- GraphQL types for the list get exposed by Postgraphile

--- a/database/migration/databaseMethods.ts
+++ b/database/migration/databaseMethods.ts
@@ -22,6 +22,8 @@ const databaseMethods = {
       if (!options?.silent) console.log('Problem altering schema:', errorMessage(err), '\n')
     }
   },
+  // Make base "query" method available unmodified
+  query: DBConnect.query,
   getDatabaseVersion: async () => {
     const text = `SELECT name, value, timestamp
       FROM system_info

--- a/database/migration/migrateData.ts
+++ b/database/migration/migrateData.ts
@@ -1163,7 +1163,7 @@ const migrateData = async () => {
   }
 
   if (databaseVersionLessThan('1.2.1')) {
-    console.log('Migrating to v1.2.0...')
+    console.log('Migrating to v1.2.1...')
 
     console.log(' - Regenerating all reviewer actions (This may take a while)')
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conforma-server",
-  "version": "1.1.14",
+  "version": "1.2.0-0",
   "main": "server.js",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conforma-server",
-  "version": "1.3.0-0",
+  "version": "1.2.0-1",
   "main": "server.js",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conforma-server",
-  "version": "1.2.0-0",
+  "version": "1.3.0-0",
   "main": "server.js",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conforma-server",
-  "version": "1.2.0",
+  "version": "1.2.1-0",
   "main": "server.js",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conforma-server",
-  "version": "1.2.1-0",
+  "version": "1.2.1",
   "main": "server.js",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "migrate": "ts-node ./database/migration/migrateData.ts --migrate",
     "cleanup": "ts-node ./src/components/files/cleanup.ts --cleanup",
     "backup": "ts-node ./src/components/exportAndImport/backup.ts --backup",
-    "archive": "ts-node ./src/components/files/archive.ts --archive"
+    "archive": "ts-node ./src/components/files/archive.ts --archive",
+    "update-reviewer-stats": "ts-node ./src/components/database/updateReviewerStats.ts --update-reviewer-stats"
   },
   "dependencies": {
     "@fastify/websocket": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conforma-server",
-  "version": "1.2.0-1",
+  "version": "1.2.0-2",
   "main": "server.js",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conforma-server",
-  "version": "1.2.0-2",
+  "version": "1.2.0",
   "main": "server.js",
   "license": "MIT",
   "repository": {

--- a/plugins/action_generate_review_assignment_records/src/generateReviewAssignments.test.ts
+++ b/plugins/action_generate_review_assignment_records/src/generateReviewAssignments.test.ts
@@ -4,7 +4,7 @@
 // database has entered correct information
 
 import { map, omit } from 'lodash'
-import DBConnect from '../../../src/components/databaseConnect'
+import DBConnect from '../../../src/components/database/databaseConnect'
 import { ActionQueueStatus, ReviewAssignmentStatus } from '../../../src/generated/graphql'
 import { action as generateReviewAssignments } from './index'
 import { ResultObject } from './types'

--- a/plugins/action_grant_permissions/src/grantPermissions.test.ts
+++ b/plugins/action_grant_permissions/src/grantPermissions.test.ts
@@ -1,7 +1,7 @@
 // Test suite for the grantPermissions Action -- adds a permisison to valerio user to reviewOrgRego
 // Ideally would verify that logic works by checking db (permission_join table) before and after
 
-import DBConnect from '../../../src/components/databaseConnect'
+import DBConnect from '../../../src/components/database/databaseConnect'
 import { ActionQueueStatus } from '../../../src/generated/graphql'
 import { action as grantPermissions } from './index'
 

--- a/plugins/action_modify_record/src/modifyRecord.test.ts
+++ b/plugins/action_modify_record/src/modifyRecord.test.ts
@@ -1,7 +1,7 @@
 // Test suite for the modifyRecord AND modifyMultipleRecords Actions
 // Needs fresh database `yarn database_init`
 
-import DBConnect from '../../../src/components/databaseConnect'
+import DBConnect from '../../../src/components/database/databaseConnect'
 import { ActionQueueStatus } from '../../../src/generated/graphql'
 import { ActionApplicationData } from '../../../src/types'
 import { action as modifyRecord } from './index'

--- a/plugins/action_trim_responses/src/trimResponses.test.ts
+++ b/plugins/action_trim_responses/src/trimResponses.test.ts
@@ -1,6 +1,6 @@
 // Test suite for the testResponses Action.
 
-import DBConnect from '../../../src/components/databaseConnect'
+import DBConnect from '../../../src/components/database/databaseConnect'
 import { ActionQueueStatus } from '../../../src/generated/graphql'
 import { action as trimResponses } from './index'
 

--- a/plugins/action_trim_responses/src/trimResponsesWithoutDatabase.test.ts
+++ b/plugins/action_trim_responses/src/trimResponsesWithoutDatabase.test.ts
@@ -1,6 +1,6 @@
 // Test suite for the testResponses Action.
 
-import DBConnect from '../../../src/components/databaseConnect'
+import DBConnect from '../../../src/components/database/databaseConnect'
 import { ActionQueueStatus, Reviewability } from '../../../src/generated/graphql'
 import { action as trimResponses } from './index'
 import * as DatabaseMethods from './databaseMethods'

--- a/plugins/action_update_review_visibility/src/updateReviewVisibility.test.ts
+++ b/plugins/action_update_review_visibility/src/updateReviewVisibility.test.ts
@@ -1,6 +1,6 @@
 // Test suite for the updateReviewVisibility Action
 
-import DBConnect from '../../../src/components/databaseConnect'
+import DBConnect from '../../../src/components/database/databaseConnect'
 import { ActionQueueStatus } from '../../../src/generated/graphql'
 import { action as updateReviewVisibility } from './index'
 

--- a/src/components/actions/throttle.ts
+++ b/src/components/actions/throttle.ts
@@ -19,10 +19,14 @@
  */
 const THROTTLE_QUEUE_THRESHOLD = 200 // ms
 
-type EventObject<T, U> = { name: string; data: T; action: (data: T) => Promise<U> | U }
+interface EventObject<T> {
+  name: string
+  data: T
+  action: (data: T) => unknown
+}
 
 export class EventThrottle {
-  queue: EventObject<any, any>[]
+  queue: EventObject<any>[]
   timerId: NodeJS.Timeout | undefined
   queueActive: boolean
 
@@ -50,7 +54,7 @@ export class EventThrottle {
     this.queueActive = false
   }
 
-  public add<T, U>(event: EventObject<T, U>): void {
+  public add<T>(event: EventObject<T>): void {
     // Timer is used solely to determine whether to put new events at the front
     // or end of the queue.
     const currentTimer = this.timerId

--- a/src/components/actions/throttle.ts
+++ b/src/components/actions/throttle.ts
@@ -21,8 +21,8 @@ const THROTTLE_QUEUE_THRESHOLD = 200 // ms
 
 type EventObject<T, U> = { name: string; data: T; action: (data: T) => Promise<U> | U }
 
-export class EventThrottle<T, U> {
-  queue: EventObject<T, U>[]
+export class EventThrottle {
+  queue: EventObject<any, any>[]
   timerId: NodeJS.Timeout | undefined
   queueActive: boolean
 
@@ -50,7 +50,7 @@ export class EventThrottle<T, U> {
     this.queueActive = false
   }
 
-  public add(event: EventObject<T, U>): void {
+  public add<T, U>(event: EventObject<T, U>): void {
     // Timer is used solely to determine whether to put new events at the front
     // or end of the queue.
     const currentTimer = this.timerId

--- a/src/components/actions/throttle.ts
+++ b/src/components/actions/throttle.ts
@@ -47,7 +47,11 @@ export class EventThrottle {
       if (next) {
         const { data, action, name } = next
         console.log('Processing queued event', name)
-        await action(data)
+        try {
+          await action(data)
+        } catch (e) {
+          console.log('Error while running throttled action: ', e)
+        }
         console.log(`${this.queue.length} events remaining in queue`)
       }
     }

--- a/src/components/database/postgresConnect.ts
+++ b/src/components/database/postgresConnect.ts
@@ -25,6 +25,7 @@ import {
 } from '../../generated/graphql'
 import { errorMessage } from '../utilityFunctions'
 import { EventThrottle } from '../actions/throttle'
+import { updateReviewerStats } from './updateReviewerStats'
 
 const Throttle = new EventThrottle<TriggerPayload, ActionResult[]>()
 
@@ -52,6 +53,7 @@ class PostgresDB {
     listener.query('LISTEN trigger_notifications')
     listener.query('LISTEN action_notifications')
     listener.query('LISTEN file_notifications')
+    listener.query('LISTEN update_reviewer_stats_notification')
     listener.on('notification', async ({ channel, payload }) => {
       if (!payload) {
         console.log(`Notification ${channel} received with no payload!`)
@@ -89,6 +91,8 @@ class PostgresDB {
           }
         case 'file_notifications':
           deleteFile(payloadObject)
+        case 'update_reviewer_stats_notification':
+          updateReviewerStats(payloadObject)
       }
     })
   }

--- a/src/components/database/postgresConnect.ts
+++ b/src/components/database/postgresConnect.ts
@@ -25,7 +25,7 @@ import {
 } from '../../generated/graphql'
 import { errorMessage } from '../utilityFunctions'
 import { EventThrottle } from '../actions/throttle'
-import { updateReviewerStats } from './updateReviewerStats'
+import { updateReviewerStatsFromDBEvent } from './updateReviewerStats'
 
 const Throttle = new EventThrottle<TriggerPayload, ActionResult[]>()
 
@@ -92,7 +92,9 @@ class PostgresDB {
         case 'file_notifications':
           deleteFile(payloadObject)
         case 'update_reviewer_stats_notification':
-          updateReviewerStats(payloadObject)
+          // Time delay so this aggregation process doesn't slow down Action
+          // execution
+          setTimeout(() => updateReviewerStatsFromDBEvent(payloadObject), 5000)
       }
     })
   }

--- a/src/components/database/postgresConnect.ts
+++ b/src/components/database/postgresConnect.ts
@@ -13,9 +13,9 @@ import {
   FilePayload,
   TriggerQueueUpdatePayload,
   UserOrg,
-  DBOperationType,
-  TriggerPayload,
   ActionResult,
+  TriggerPayload,
+  DBOperationType,
 } from '../../types'
 import {
   ApplicationOutcome,
@@ -68,7 +68,7 @@ class PostgresDB {
           config.Throttle.add({
             name: `Trigger ${trigger} on ${table}, id ${record_id}`,
             data: { ...payloadObject, data },
-            action: processTrigger as (input: TriggerPayload) => Promise<ActionResult[]>,
+            action: processTrigger,
           })
           break
         case 'action_notifications':
@@ -97,7 +97,6 @@ class PostgresDB {
             data: payloadObject,
             action: updateReviewerStatsFromDBEvent,
           })
-        // setTimeout(() => updateReviewerStatsFromDBEvent(payloadObject), 5000)
       }
     })
   }

--- a/src/components/database/updateReviewerStats.ts
+++ b/src/components/database/updateReviewerStats.ts
@@ -1,0 +1,179 @@
+/**
+ * Function to update reviewer/assigner stats:
+ * - the "reviewer_list" and "assigner_list" on application
+ * - the "application_reviewer_action" table, which contains a list of every
+ *   reviewer's possible actions (Assign, Review, Re-assign, etc) for every
+ *   application they could be interacting with
+ *
+ * It is called by a notification listener (in postgresConnect), which notified
+ * by triggers on various tables (see the cases below). Putting it here rather
+ * than as a database PG function allows it to be run asynchronously and not
+ * block other updates (as this process can be somewhat slow when there are a
+ * lot of applications and reviewers in the system).
+ */
+
+import DBConnect from '../../components/database/databaseConnect'
+import { errorMessage } from '../utilityFunctions'
+import config from '../../config'
+
+interface NotificationPayload {
+  tableName: string
+  data: Record<string, unknown>
+  operation: 'UPDATE' | 'INSERT'
+}
+
+export const updateReviewerStats = async ({ tableName, data, operation }: NotificationPayload) => {
+  let applicationId: number = 0
+  let reviewerIds: number[] = []
+
+  const db = databaseMethods
+
+  console.log({ tableName, data, operation })
+  console.log(`Updating reviewer action stats due to ${operation} trigger on table: ${tableName} `)
+
+  switch (tableName) {
+    case 'review_assignment':
+      applicationId = data.application_id as number
+      if (operation === 'INSERT') {
+        reviewerIds.push(data.reviewer_id as number)
+      }
+      if (operation === 'UPDATE') {
+        reviewerIds = await db.getAllStaffForApplication(applicationId)
+      }
+      break
+    case 'review_assignment_assigner_join':
+      applicationId = await db.getApplicationIdFromReviewAssignment(
+        data.review_assignment_id as number
+      )
+      reviewerIds.push(data.assigner_id as number)
+      break
+    case 'review_status_history':
+      break
+    case 'application':
+      break
+  }
+
+  // Update reviewer/assigner lists on application table
+  console.log('Updating reviewer/assigner lists for application:', applicationId)
+  await db.updateApplicationStaffLists(applicationId)
+
+  // Update application_reviewer_actions
+  reviewerIds = reviewerIds.filter((id) => id !== null)
+
+  for (const userId of reviewerIds) {
+    console.log(`Updating actions for user ${userId} on application ${applicationId}`)
+    await db.upsertReviewerAction(applicationId, userId)
+  }
+
+  // Clean up NULL records
+  await db.cleanupNullReviewerActions(applicationId)
+}
+
+const databaseMethods = {
+  updateApplicationStaffLists: async (appId: number) => {
+    try {
+      const text = `
+        WITH lists AS (
+                SELECT reviewers, assigners
+                FROM single_application_detail($1)
+            ) 
+        UPDATE public.application
+            SET reviewer_list = (SELECT reviewers FROM lists),
+            assigner_list = (SELECT assigners FROM lists)
+            WHERE id = $1;`
+      await DBConnect.query({
+        text,
+        values: [appId],
+      })
+    } catch (err) {
+      console.log('ERROR updating staff lists for application', appId)
+      console.log(errorMessage(err))
+      throw err
+    }
+  },
+  getAllStaffForApplication: async (appId: number) => {
+    try {
+      const text = `
+        SELECT DISTINCT UNNEST(ARRAY[reviewer_id, raaj.assigner_id])
+        FROM review_assignment ra
+        LEFT JOIN review_assignment_assigner_join raaj
+        ON ra.id = raaj.review_assignment_id
+        WHERE application_id = $1;
+        `
+      const result = await DBConnect.query({
+        text,
+        values: [appId],
+        rowMode: 'array',
+      })
+      return result.rows.flat()
+    } catch (err) {
+      console.log('ERROR getting staff lists for application', appId)
+      console.log(errorMessage(err))
+      throw err
+    }
+  },
+  getApplicationIdFromReviewAssignment: async (assignmentId: number) => {
+    try {
+      const text = `
+        SELECT application_id FROM review_assignment
+            WHERE id = $1;
+        `
+      const result = await DBConnect.query({
+        text,
+        values: [assignmentId],
+        rowMode: 'array',
+      })
+      return result.rows[0].application_id
+    } catch (err) {
+      console.log('ERROR getting applicationId for reviewAssignment', assignmentId)
+      console.log(errorMessage(err))
+      throw err
+    }
+  },
+  upsertReviewerAction: async (appId: number, userId: number) => {
+    try {
+      const text = `
+        WITH actions AS (
+            SELECT reviewer_action, assigner_action
+                FROM single_application_detail($1, $2)
+            ) 
+        INSERT INTO public.application_reviewer_action
+            (user_id, application_id, reviewer_action, assigner_action)  
+        VALUES(
+            $2,
+            $1,
+            (SELECT reviewer_action FROM actions),
+            (SELECT assigner_action FROM actions)
+        )
+        ON CONFLICT (user_id, application_id)
+        DO UPDATE
+            SET reviewer_action = (SELECT reviewer_action FROM actions),
+            assigner_action = (SELECT assigner_action FROM actions);`
+      await DBConnect.query({
+        text,
+        values: [appId, userId],
+      })
+    } catch (err) {
+      console.log(`ERROR updating actions for user ${userId} on application ${appId}`)
+      console.log(errorMessage(err))
+      throw err
+    }
+  },
+  cleanupNullReviewerActions: async (appId: number) => {
+    try {
+      const text = `
+        DELETE FROM public.application_reviewer_action
+        WHERE application_id = $1
+        AND reviewer_action IS NULL
+        AND assigner_action IS NULL;`
+      await DBConnect.query({
+        text,
+        values: [appId],
+      })
+    } catch (err) {
+      console.log(`ERROR cleaning up actions for application ${appId}`)
+      console.log(errorMessage(err))
+      throw err
+    }
+  },
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,14 +3,7 @@ import { DateTime, Settings } from 'luxon'
 import preferences from '../preferences/preferences.json'
 import { readFileSync } from 'fs'
 import { version } from '../package.json'
-import {
-  serverPrefKeys,
-  ServerPreferences,
-  WebAppPrefs,
-  Config,
-  TriggerPayload,
-  ActionResult,
-} from './types'
+import { serverPrefKeys, ServerPreferences, WebAppPrefs, Config } from './types'
 import { EventThrottle } from './components/actions/throttle'
 const serverPrefs: ServerPreferences = preferences.server as ServerPreferences
 const isProductionBuild = process.env.NODE_ENV === 'production'
@@ -36,9 +29,11 @@ Operation modes:
 */
 
 // Global Throttle instance, for spacing out processing when (potentially)
-// several hundred events occur simultaneously
+// several hundred events occur simultaneously, or for making sure a particular
+// function waits till an existing (throttled) event is complete
 const Throttle = new EventThrottle()
 
+// Global config object
 const config: Config = {
   pg_database_connection: {
     user: 'postgres',

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ import { EmailOperationMode } from './config'
 import { PoolConfig } from 'pg'
 import { Schedulers } from './components/scheduler'
 import { ExternalApiConfigs } from './components/external-apis/types'
+import { EventThrottle } from './components/actions/throttle'
 
 export interface ActionInTemplate {
   code: string
@@ -383,6 +384,7 @@ interface ConfigBase {
   isLiveServer: boolean
   emailMode: EmailOperationMode
   maintenanceMode: boolean
+  Throttle: EventThrottle
 }
 
 export type Config = ConfigBase & ServerPreferences & { scheduledJobs?: Schedulers }


### PR DESCRIPTION
Fix #1120 

### Main changes:
- Remove the "Insert" trigger for `review_assignment` and `review_assignment_assigner_join`, as this was causing the update function to run way too many times[^1] whenever review assignments were generated. Instead it just gets run once and is called by the `generateReviewAssignments` Action.
- Move the "updateReviewerStats" function to a server function, triggered by database notification (and other things) rather than a PG function. Makes it much easier to see when it's running
- Made sure "updateReviewerStats" gets called async and send to the Throttle queue, which means it has to wait until the current action sequence is complete, and won't block the UI (as the Action triggers don't wait for it)

### Additional related changes
- Make `updateReviewerStats` callable by command line, so we can run manually on existing applications if desired
- Make Throttle a global object so can be used by more than just the database trigger functions (and update types accordingly)
- Data migration to re-calculate reviewer actions for existing applications (that have reviewer actions currently), as we had a few where they were showing up as "Assignable" even though they were approved.


[^1]: It was running for a single reviewer for each insert, whereas now it runs once for all reviewers. I didn't realise quite how bad it was, due to two things:
    - even though it only runs for a single reviewer, the reviewer and assigner lists for the application table were being re-calculated every time, which was very wasteful
    - the `review_assignment_assigner_join` captures a many-to-many relation, so by calling the function on every insert, the number of potential assigners for each application can be quite large (they get repeated for *each* review assignment, so there was 112 in the case that was making this problem noticeable on the Fiji server). And because a lot of them were self-assigning, it's the same person for a lot of them. So we would be getting well over a hundred calls for what boiled down to about 10 actual users. i.e. if it had only been running once per person, it might have been okay, but once per assigner-assignment join was too much!